### PR TITLE
解决flash模式自带id，html5没有id的问题

### DIFF
--- a/src/jquery.uploader.js
+++ b/src/jquery.uploader.js
@@ -804,12 +804,12 @@
      * @return {String} 文件尺寸，如"100kb"
      */
     function stringifySize(bytes){
-        var i = -1;
+        var i = 0;
         while (bytes > 1000) {
             bytes = bytes / 1024;
             i++;
         }
-        return Math.max(bytes, 0.1).toFixed(1) + ['KB', 'M', 'G', 'T'][i];
+        return Math.max(bytes, 0.1).toFixed(1) + ['B', 'KB', 'M', 'G', 'T'][i];
     }
     
     /**

--- a/src/jquery.uploader.js
+++ b/src/jquery.uploader.js
@@ -353,6 +353,7 @@
                 $.each(fileList, function(i, file){
                     var _err;
                     f = new _File(+i, file);
+                    file.id = f.id;//flash模式自带id，html5没有id，这里直接设置id即可
                     if (me.acceptExts !== '*' && !_acceptType.call(me, file.name)) { //排除不允许的文件类型
                         me.onError( {code: 601, params: [acceptExts]}, false );
                         return;


### PR DESCRIPTION
flash模式自带id，html5没有id，这里直接设置id即可。
主要解决opt.onAddQueue.call时，无法获取id的bug
